### PR TITLE
Don't output non referenced props in dom

### DIFF
--- a/v-snackbars.vue
+++ b/v-snackbars.vue
@@ -25,6 +25,7 @@
 <script>
 export default {
   name:'v-snackbars',
+  inheritAttrs: false,
   props:{
     'messages':{
       type:Array,


### PR DESCRIPTION
Props will appear in the dom because this acts as a proxy without defining props as such inheritAttrs should be set to false