### PR TITLE
Fix snackbar position

### DIFF
--- a/v-snackbars.vue
+++ b/v-snackbars.vue
@@ -38,7 +38,7 @@
       {{topOrBottom[key]}}: 0;
       }
       .v-snackbars.v-snackbars-{{identifier}}-{{key}} > .v-snack__wrapper {
-      {{topOrBottom[key]}}:{{ indexPosition[key]*distances[key] }}px;
+      {{topOrBottom[key]}}:{{ calcDistance(key) }}px;
       }
     </css-style>
   </div>
@@ -150,6 +150,17 @@ export default {
     }
   },
   methods: {
+    calcDistance(key) {
+      let distance = 0;
+      if (typeof this.distances[key] !== 'undefined') {
+        for (let idx in this.indexPosition) {
+          if (typeof this.distances[idx] === 'undefined') continue;
+          distance += this.distances[idx];
+          if (idx == key) break;
+        }
+      }
+      return distance;
+    },
     getProp(prop, i) {
       if (this.objects.length > i && typeof this.objects[i][prop] !== 'undefined')
         return this.objects[i][prop];


### PR DESCRIPTION
Before: 
![image](https://user-images.githubusercontent.com/10596597/114074969-49326f80-98a5-11eb-9f42-0afe46dbf1f0.png)

After:
![image](https://user-images.githubusercontent.com/10596597/114075066-65361100-98a5-11eb-8b16-aebc76c55906.png)


I got the problem in 2 cases:
- standard behaviour but message too long
- when I tried to use the default slot to customize the display message with a `v-html` attribute
`<template v-slot:default="{ message }">`
` <v-layout v-html="message"></v-layout>`
`</template>`

