### PR TITLE
Add support for object interactivity

### DIFF
--- a/v-snackbars.vue
+++ b/v-snackbars.vue
@@ -157,7 +157,8 @@ export default {
           right: right,
           color: this.getProp("color", i) || "black",
           transition: this.getProp("transition", i) || (right ? 'slide-x-reverse-transition' : 'slide-x-transition'),
-          show: false
+          show: false,
+          timeout: null,
         });
         this.keys.push(key);
         this.$nextTick(function() {
@@ -179,7 +180,10 @@ export default {
             // define the timeout
             let timeout = this.getProp("timeout", i);
             if (timeout > 0) {
-              setTimeout(() => this.removeMessage(key, true), timeout * 1);
+              this.snackbars[i].timeout = setTimeout(
+                () => this.removeMessage(key, true),
+                timeout * 1
+              )
             }
           });
         })
@@ -270,7 +274,28 @@ export default {
           else if (elemsLen > 0) {
             // or we set a value on an element using this.$set, so we update the message
             for (let i=2; i<elemsLen+2; i++) {
-              if (_this.snackbars[idx]) _this.$set(_this.snackbars[idx], 'message', args[i]);
+              if (
+                typeof args[i] === 'string' ||
+                typeof args[i] === 'objects'
+              ) {
+                _this.$set(_this.snackbars[idx], 'message', args[i])
+              } else {
+                for (const prop in args[i]) {
+                  if (prop === 'timeout') {
+                    const timeout = args[i][prop] * 1
+                    // If there's an existing timeout, clear it before setting the new timeout
+                    if (_this.snackbars[idx].timeout) {
+                      clearTimeout(_this.snackbars[idx].timeout)
+                    }
+                    const key = _this.snackbars[idx].key
+                    _this.snackbars[idx].timeout = setTimeout(() => {
+                      _this.removeMessage(key, true)
+                    }, timeout)
+                  } else {
+                    _this.$set(_this.snackbars[idx], prop, args[i][prop])
+                  }
+                }
+              }
               idx++;
             }
           }


### PR DESCRIPTION
This is basically an untested "sketch" of an idea to address issue #17.

As currently written, updates of any kind to the _messages_ or _objects_ array that you passed into the `v-snackbars` component will only update the message. This works well for _messages_ which is an array of strings, but does not work so well for _objects_ which is an array of objects, since the message will be updated to the string representation of the object you're trying to update.

This change detects whether we're attempting to update a string (or string object). If we are, we keep the current behavior. Otherwise (and this is perhaps _too_ naive), we iterate over the object, and `$set` props on the `v-snackbar` component to their updated values. For `timeout`s we take special care, since the timeout is being controlled out-of-band from the `v-snackbar` component. If `timeout` is being updated, we first clear the existing timeout if it exists before adding the new timeout.

I'm sure I've missed a corner case or two, but I'm hoping this PR gives you an idea of what I'm trying to achieve.