### PR TITLE
Added index, id to default slot

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ You can use `v-slot:default` to customize the content of the snackbar.
 For example:
 ```vue
 <v-snackbars :messages.sync="messages" :timeout="-1" color="black" top right>
-  <template v-slot:default="{ message }">
+  <template v-slot:default="{ message, id, index }">
     <h3 class="mb-2">Header</h3>
     {{ message }}
   </template>
@@ -67,6 +67,8 @@ For example:
 
 The parameter:
   - `message`: the current message that is displayed in the notification
+  - `id`: the unique key/id of the message
+  - `index`: the index in the array of notifications/messages
 
 #### Personalized button
 

--- a/v-snackbars.vue
+++ b/v-snackbars.vue
@@ -17,7 +17,11 @@
       v-for="(snackbar, idx) in snackbars"
     >
       <template v-slot:default>
-        <slot :message="snackbar.message">
+        <slot 
+          :message="snackbar.message"
+          :id="snackbar.key"
+          :index="idx"
+        >
           {{ snackbar.message }}
         </slot>
       </template>


### PR DESCRIPTION
It would be useful to have to index/id exposed via the default slot to make use of any snackbar options outside of the component.